### PR TITLE
[DEP-154] Release 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 All notable changes to this project will be documented in this file.
-## [2.3.1] - 2020-07-14
+## [2.3.1] - 2020-07-21
 ### Fixed
 - Solved incompatibility issue with **Firebase Performance gradle plugin**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
+## [2.3.1] - 2020-07-14
+### Fixed
+- Solved incompatibility issue with **Firebase Performance gradle plugin**
+
 ## [2.3.0] - 2020-06-26
 ### Changed
 - Zoom Liveness flow update

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ Add modules you require to your build.gradle:
 ```groovy
 dependencies {
     //If you need document capture
-    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-doc-scan:2.3.0'
+    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-doc-scan:2.3.1'
 
     //If you need liveness
-    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-liveness-zoom:2.3.0'
+    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-liveness-zoom:2.3.1'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -76,13 +76,32 @@ Also you will need to add the following to your app-level build.gradle file, ins
 If you get an error `Unable to find a matching variant of com.yoti.mobile.mpp:mrtddump-android`, you should also add
 ```groovy
     android {
+        ...
         buildTypes {
+            ...
             debug {
+                ...
                 matchingFallbacks = ['release']
             }
          }
     }
-``` 
+```
+
+And if you're using [Firebase performance gradle Plugin](https://firebase.google.com/docs/perf-mon/disable-sdk?platform=android), you'll need to disable it for debug build variant:
+```groovy
+    android {
+        ...
+        buildTypes {
+            ...
+            debug {
+                ...
+                FirebasePerformance {
+                    instrumentationEnabled false
+                }
+            }
+         }
+    }
+```
 
 ### Proguard
 If you are using Proguard, you will need to add the following lines in its configuration file:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,6 +42,6 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.core:core-ktx:1.3.0'
 
-    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-doc-scan:2.3.0'
-    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-liveness-zoom:2.3.0'
+    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-doc-scan:2.3.1'
+    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-liveness-zoom:2.3.1'
 }


### PR DESCRIPTION
Release 2.3.1

[Release Notes](https://lampkicking.atlassian.net/browse/DEP-154)

### B&T

- Update public demo app by adding [Firebase Performance gradle plugin](https://firebase.google.com/docs/perf-mon/get-started-android)
- Disable it for debug mode:
```
 buildTypes {
            ...
            debug {
                ...
                FirebasePerformance {
                    instrumentationEnabled false
                }
            }
         }
```
- Use two steps config sessionId in production.

- [x] Build Variant - DEBUG: 
You're able to complete document auth + liveness flow.

- [x] Build Variant - RELEASE:
You're able to complete document auth + liveness flow.