### PR TITLE
[DEP-162] Changelog correction: New Filipino ID docs were added in 2.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Supplementary documents functionality: Integrators will now be able to verify the user's address by supplementary documents module integration.
 Documents supported: Utility Bill, Council Tax Bill & Phone Bill.
-- New ID documents supported: Filipino Professional ID & Voter ID
 
 ## [2.3.2] - 2020-08-03
 ### Added


### PR DESCRIPTION
Filipino Professional ID and Voter ID were already added in 2.3.2

Related to [DEP-162](https://lampkicking.atlassian.net/browse/DEP-162)