### PR TITLE
[DEP-197] Bump SDK version to 2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
+## [2.6.1] - 2021-03-24
+### Fixed
+- Solved issue happened in some sessions.
+
 ## [2.6.0] - 2021-03-05
 ### Added
 - Support for custom privacy policy link.

--- a/README.md
+++ b/README.md
@@ -55,13 +55,13 @@ Add modules you require to your build.gradle:
 ```groovy
 dependencies {
     //If you need document capture
-    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-doc-scan:2.6.0'
+    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-doc-scan:2.6.1'
     
     //If you need supplementary documents
-    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-doc-scan-sup:2.6.0'
+    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-doc-scan-sup:2.6.1'
 
     //If you need liveness
-    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-liveness-zoom:2.6.0'
+    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-liveness-zoom:2.6.1'
 }
 ```
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "com.yoti.mobile.android.sdk.yotidocscan.sample"
         minSdkVersion 21
         targetSdkVersion 30
-        versionCode 260
-        versionName "2.6.0"
+        versionCode 261
+        versionName "2.6.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -43,8 +43,8 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.core:core-ktx:1.3.2'
 
-    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-doc-scan:2.6.0'
-    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-doc-scan-sup:2.6.0'
-    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-liveness-zoom:2.6.0'
+    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-doc-scan:2.6.1'
+    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-doc-scan-sup:2.6.1'
+    implementation 'com.yoti.mobile.android.sdk:yoti-sdk-liveness-zoom:2.6.1'
 
 }

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <dimen name="margin">16dp</dimen>
+
+</resources>


### PR DESCRIPTION

### Description
Release 2.6.1

### References

Deployment ticket: [DEP-197](https://lampkicking.atlassian.net/browse/DEP-197)
Release content: [Release 2.6.1](https://lampkicking.atlassian.net/projects/YD/versions/41796/tab/release-report-warnings) 

Tagged
@lampkicking/android-dev
