### PR TITLE
[YD-5043] Remove deprecated message from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,20 +82,6 @@ Also you will need to add the following to your app-level build.gradle file, ins
     }
 ```
 
-If you get an error `Unable to find a matching variant of com.yoti.mobile.mpp:mrtddump-android`, you should also add
-```groovy
-    android {
-        ...
-        buildTypes {
-            ...
-            debug {
-                ...
-                matchingFallbacks = ['release']
-            }
-         }
-    }
-```
-
 And if you're using [Firebase performance gradle Plugin](https://firebase.google.com/docs/perf-mon/disable-sdk?platform=android), you'll need to disable it for debug build variant:
 ```groovy
     android {


### PR DESCRIPTION
### Description

Update README to no longer specify deprecated troubleshooting paragraph about setting `matchingFallbacks = ['release']`.

### References

[YD-5043](https://lampkicking.atlassian.net/browse/YD-5043)

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
