### PR TITLE
[YD-5422] Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ class MainActivity : AppCompatActivity() {
         startButton.setOnClickListener {
             yotiSdk
                     .setSessionId("<Your Session ID>")
-                    .setSessionToken("<Your Session Token>")
+                    .setClientSessionToken("<Your Session Token>")
                     .start(this)
         }
 
@@ -150,7 +150,7 @@ By default Activity request code is 9001 and you can handle it in `onActivityRes
 ```kotlin
             yotiSdk
                     .setSessionId("<Your Session ID>")
-                    .setSessionToken("<Your Session Token>")
+                    .setClientSessionToken("<Your Session Token>")
                     .start(this, <Your Request Code>)
 ```
 


### PR DESCRIPTION
Replace references to `setSessionToken` with `setClientSessionToken` since only the latter actually exists.

[YD-5422](https://lampkicking.atlassian.net/browse/YD-5422)

[YD-5422]: https://lampkicking.atlassian.net/browse/YD-5422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ